### PR TITLE
Increase build number to force newer build with (hopefully) fixed GSL for galpy v1.3.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
   '{{ hash_type }}': '{{ hash_value }}'
 
 build:
-  number: 0
+  number: 1
   script: python setup.py install --single-version-externally-managed --record=record.txt  # [win]
   script: CPATH="$PREFIX/include:$CPATH" python setup.py install --single-version-externally-managed --record=record.txt --no-openmp  # [osx]
   script: CPATH="$PREFIX/include:$CPATH" python setup.py install --single-version-externally-managed --record=record.txt  # [not win and not osx]


### PR DESCRIPTION
Checklist
* [x] Used a fork of the feedstock to propose changes
* [x] Bumped the build number (if the version is unchanged)

Re-building because the default ``v1.3.0`` conda installation appears to choose the wrong version of the GSL dependency. Seems to be fixed in the updated template PR #3, but that PR didn't increase the build number and now there are two build for ``v1.3.0`` when doing ``conda search galpy`` and the wrong one seems to get installed by default. Hopefully just increasing the build number will fix all of these issues (the #3 build works fine when installed like ``conda install galpy==1.3.0=py36hb26f9ae_0  -c conda-forge``)